### PR TITLE
Add support for activejob version 6

### DIFF
--- a/active_job_lock.gemspec
+++ b/active_job_lock.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.homepage          = 'http://github.com/dferrazm/active_job_lock'
   s.email             = ''
   s.authors           = ['Daniel Ferraz', 'Luke Antins']
-  s.has_rdoc          = false
 
   s.files             = %w(README.md Rakefile LICENSE HISTORY.md)
   s.files            += Dir.glob('lib/**/*')

--- a/active_job_lock.gemspec
+++ b/active_job_lock.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob('lib/**/*')
   s.files            += Dir.glob('test/**/*')
 
-  s.add_dependency('activejob', '< 6.0')
+  s.add_dependency('activejob', '< 7')
   s.add_dependency('redis', '< 5.0')
   s.add_development_dependency('rake', '~> 10.3')
   s.add_development_dependency('minitest', '~> 5.8.4')


### PR DESCRIPTION
I've ran the spec locally with activejob (6.0.3.1) ✅ 

```ruby
.

Fabulous run in 7.039426s, 0.7103 runs/s, 1.4206 assertions/s.

5 runs, 10 assertions, 0 failures, 0 errors, 0 skips
```